### PR TITLE
Rename File

### DIFF
--- a/lib/app/constant/resources/app_string.dart
+++ b/lib/app/constant/resources/app_string.dart
@@ -1,0 +1,5 @@
+class AppString {
+  static const String welcomeText = "welcome_text";
+  static const String changeTo = "change_to";
+  static const String hello = "hello";
+}

--- a/lib/app/constant/routing/app_pages.dart
+++ b/lib/app/constant/routing/app_pages.dart
@@ -1,11 +1,10 @@
+import 'package:get/get.dart';
 import 'package:getx_architecture/app/constant/routing/app_route.dart';
 import 'package:getx_architecture/app/core/binding/initial_binding.dart';
 import 'package:getx_architecture/app/features/change_language/binding/change_language_binding.dart';
 import 'package:getx_architecture/app/features/change_language/screen/change_language_screen.dart';
 import 'package:getx_architecture/app/features/sample_feature/binding/sample_binding.dart';
 import 'package:getx_architecture/app/features/sample_feature/screens/sample_screen.dart';
-import 'package:get/get.dart';
-
 
 class AppPages {
   AppPages._();

--- a/lib/app/constant/translation/app_translation.dart
+++ b/lib/app/constant/translation/app_translation.dart
@@ -4,6 +4,9 @@ import 'languages/ch.dart';
 import 'languages/en.dart';
 import 'languages/my.dart';
 
+const translationNameKey = "name";
+const translationLocaleKey = "locale";
+
 abstract class AppTranslation {
   static Map<String, Map<String, String>> translationsKeys = {
     "en_US": enLanguage,
@@ -13,16 +16,16 @@ abstract class AppTranslation {
 
   static List<Map<String, dynamic>> locales = [
     {
-      'name': 'English',
-      'locale': const Locale('en', 'US'),
+      translationNameKey: 'English',
+      translationLocaleKey: const Locale('en', 'US'),
     },
     {
-      'name': 'Myanmar',
-      'locale': const Locale('my', 'MM'),
+      translationNameKey: 'Myanmar',
+      translationLocaleKey: const Locale('my', 'MM'),
     },
     {
-      'name': 'Chinese',
-      'locale': const Locale('ch', 'CH'),
+      translationNameKey: 'Chinese',
+      translationLocaleKey: const Locale('ch', 'CH'),
     },
   ];
 }

--- a/lib/app/constant/translation/languages/ch.dart
+++ b/lib/app/constant/translation/languages/ch.dart
@@ -1,5 +1,7 @@
+import '../../resources/app_string.dart';
+
 final Map<String, String> chLanguage = {
-  'hello': "你好",
-  'change_to': "中国人",
-  'welcome_text': "用于大型项目的 GetX 架构",
+  AppString.hello: "你好",
+  AppString.changeTo: "中国人",
+  AppString.welcomeText: "用于大型项目的 GetX 架构",
 };

--- a/lib/app/constant/translation/languages/en.dart
+++ b/lib/app/constant/translation/languages/en.dart
@@ -1,5 +1,7 @@
+import 'package:getx_architecture/app/constant/resources/app_string.dart';
+
 final Map<String, String> enLanguage = {
-  'hello': "Hello",
-  'change_to': "English",
-  'welcome_text': "GetX architecture for large scale project",
+  AppString.hello: "Hello",
+  AppString.changeTo: "English",
+  AppString.welcomeText: "GetX architecture for large scale project",
 };

--- a/lib/app/constant/translation/languages/my.dart
+++ b/lib/app/constant/translation/languages/my.dart
@@ -1,5 +1,7 @@
+import 'package:getx_architecture/app/constant/resources/app_string.dart';
+
 final Map<String, String> myLanguage = {
-  'hello': "မင်္ဂလာပါ",
-  'change_to': "မြန်မာ",
-  'welcome_text': "အကြီးစားပရောဂျက်အတွက် GetX Architecture",
+  AppString.hello: "မင်္ဂလာပါ",
+  AppString.changeTo: "မြန်မာ",
+  AppString.welcomeText: "အကြီးစားပရောဂျက်အတွက် GetX Architecture",
 };

--- a/lib/app/data/network/services/dio_provider.dart
+++ b/lib/app/data/network/services/dio_provider.dart
@@ -6,8 +6,8 @@ import 'package:get/get.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 class DioProvider {
-  static final String baseUrl = "BuildConfig.instance.config.baseUrl";
-  static final String chatBaseUrl = "BuildConfig.instance.config.chatBaseUrl";
+  static const String baseUrl = "BuildConfig.instance.config.baseUrl";
+  static const String chatBaseUrl = "BuildConfig.instance.config.chatBaseUrl";
   static Dio? _instance;
 
   static const int _maxLineWidth = 90;

--- a/lib/app/features/change_language/controller/change_language_controller.dart
+++ b/lib/app/features/change_language/controller/change_language_controller.dart
@@ -1,10 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:getx_architecture/app/constant/enum/request_language_enum.dart';
+import 'package:getx_architecture/app/constant/resources/app_string.dart';
 import 'package:getx_architecture/app/core/base/base_controller.dart';
 import 'package:getx_architecture/app/core/utils/app_utils.dart';
 import 'package:getx_architecture/app/data/local/cache_manager.dart';
 import 'package:getx_architecture/app/data/view_object/setup_vo.dart';
-import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 
 class ChangeLanguageController extends BaseController {
   RxInt changeLanguageGroupLanguage = 0.obs;
@@ -23,7 +24,7 @@ class ChangeLanguageController extends BaseController {
     setData(CacheManagerKey.countryCode, locale.countryCode);
     //Future.delayed(Duration(seconds: 2), () => Get.back());
     Get.back();
-    AppUtils.showToast("change_to".tr);
+    AppUtils.showToast(AppString.changeTo.tr);
   }
 
   @override

--- a/lib/app/features/change_language/screen/change_language_screen.dart
+++ b/lib/app/features/change_language/screen/change_language_screen.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:getx_architecture/app/constant/resources/app_colors.dart';
 import 'package:getx_architecture/app/constant/resources/app_dimens.dart';
 import 'package:getx_architecture/app/constant/translation/app_translation.dart';
@@ -6,11 +8,6 @@ import 'package:getx_architecture/app/features/change_language/controller/change
 import 'package:getx_architecture/app/widget/default_app_bar_widget.dart';
 import 'package:getx_architecture/app/widget/secondary_button_widget.dart';
 import 'package:getx_architecture/app/widget/text_view_widget.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/basic.dart';
-import 'package:flutter/src/widgets/framework.dart';
-import 'package:flutter/src/widgets/preferred_size.dart';
-import 'package:get/get.dart';
 
 class ChangeLanguageScreen extends BaseView<ChangeLanguageController> {
   ChangeLanguageScreen({Key? key}) : super(key: key);
@@ -36,12 +33,15 @@ class ChangeLanguageScreen extends BaseView<ChangeLanguageController> {
           vertical: AppDimens.MARGIN_SMALL,
           horizontal: AppDimens.MARGIN_MEDIUM),
       child: SecondaryButtonWidget(
-          child: const TextViewWidget("Change", textColor: Colors.white,),
+          child: const TextViewWidget(
+            "Change",
+            textColor: Colors.white,
+          ),
           onPress: () {
             controller.changeLanguage(
               AppTranslation
                       .locales[controller.changeLanguageGroupLanguage.value]
-                  ['locale'],
+                  [translationLocaleKey],
             );
           }),
     );

--- a/lib/app/features/sample_feature/screens/sample_screen.dart
+++ b/lib/app/features/sample_feature/screens/sample_screen.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:getx_architecture/app/constant/resources/app_dimens.dart';
 import 'package:getx_architecture/app/constant/routing/app_route.dart';
 import 'package:getx_architecture/app/core/base/base_view.dart';
@@ -5,8 +7,8 @@ import 'package:getx_architecture/app/features/sample_feature/controller/sample_
 import 'package:getx_architecture/app/widget/default_app_bar_widget.dart';
 import 'package:getx_architecture/app/widget/text_view_widget.dart';
 import 'package:getx_architecture/app/widget/view_handling/smart_refresher_parent_view.dart';
-import 'package:flutter/material.dart';
-import 'package:get/get.dart';
+
+import '../../../constant/resources/app_string.dart';
 
 class SampleScreen extends BaseView<SampleController> {
   SampleScreen({Key? key}) : super(key: key);
@@ -14,9 +16,9 @@ class SampleScreen extends BaseView<SampleController> {
   @override
   PreferredSizeWidget? appBar(BuildContext context) {
     return DefaultAppBar(
-      title: "hello".tr,
+      title: AppString.hello.tr,
       trillingIcon: Icons.language,
-      trillingIconOnClick: ()=> Get.toNamed(Routes.changeLanguageScreen),
+      trillingIconOnClick: () => Get.toNamed(Routes.changeLanguageScreen),
     );
   }
 
@@ -28,16 +30,17 @@ class SampleScreen extends BaseView<SampleController> {
           Container(
             height: 68,
             color: Colors.green,
-            child:  Center(
-              child: TextViewWidget("welcome_text".tr, textSize: 18, textColor: Colors.white),
+            child: Center(
+              child: TextViewWidget(AppString.welcomeText.tr,
+                  textSize: 18, textColor: Colors.white),
             ),
           ),
           Flexible(
             child: SmartRefresherParentView(
               refreshController: controller.refreshController,
               enablePullUp: true,
-              onRefresh:()=> controller.resetAndGetDummyList(),
-              onLoading:()=> controller.getDummyList(),
+              onRefresh: () => controller.resetAndGetDummyList(),
+              onLoading: () => controller.getDummyList(),
               child: CustomScrollView(slivers: [
                 SliverList(
                   delegate: SliverChildBuilderDelegate(


### PR DESCRIPTION
Default App Bar Action List
Currently, only one widget is available. Sometime, we will need multiple widget in app bar. Any ideas for that problem?

Handle 401 Exception?
I don't see 401 exception in base_controller.

Can we rename cache_manager?
For me ,cache_manager is not DAO. I just know it is store pref data. So , i think we should rename it.
Can we add mapper outside of controller? Because i think controller is just need to control the view and data I/O process.
